### PR TITLE
Add Megumi kids store website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Megumi Kids Store
+
+Static website showcasing Japanese-inspired products for children aged 0–16.
+
+## Pages
+- `index.html` – home page with navigation
+- `all-products.html` – quick links to every category
+- `clothes.html` – boys and girls clothing sections
+- `toys.html` – unisex, boys, girls and toddler toys
+- `care.html` – creams and care products
+- `cart.html` – sample cart with Razorpay checkout (India)
+
+Images are loaded from public Unsplash URLs. Payment uses a Razorpay test key and does not charge real money.
+
+Open the HTML files in a browser to view the site.

--- a/README.mdgit
+++ b/README.mdgit
@@ -1,1 +1,0 @@
-"# ChatGPTWebsiteHelp"  initgit add README.mdgit commit -m "first commit"git branch -M maingit remote add origin https://github.com/pradeep1865/ChatGPTWebsiteHelp.gitgit push -u origin main

--- a/all-products.html
+++ b/all-products.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Products - Megumi</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+    <h1>All Products</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="clothes.html">Clothes</a></li>
+            <li><a href="toys.html">Toys</a></li>
+            <li><a href="care.html">Care</a></li>
+            <li><a href="cart.html">Cart</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section class="product-grid">
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=400&q=60" alt="Kids Clothes">
+            <h3><a href="clothes.html">Kids Clothes</a></h3>
+        </div>
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1601758174893-6ec2edc7c65b?auto=format&fit=crop&w=400&q=60" alt="Kids Toys">
+            <h3><a href="toys.html">Kids Toys</a></h3>
+        </div>
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1587300003388-59208cc962cb?auto=format&fit=crop&w=400&q=60" alt="Care Products">
+            <h3><a href="care.html">Creams & Care</a></h3>
+        </div>
+    </section>
+</main>
+<footer>
+    <p>&copy; 2023 Megumi. Ships within India.</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/care.html
+++ b/care.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Creams & Care - Megumi</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+    <h1>Creams & Care</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="all-products.html">All Products</a></li>
+            <li><a href="clothes.html">Clothes</a></li>
+            <li><a href="toys.html">Toys</a></li>
+            <li><a href="care.html">Care</a></li>
+            <li><a href="cart.html">Cart</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section class="product-grid">
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1596462502278-27bfdc0c4a23?auto=format&fit=crop&w=400&q=60" alt="Baby Lotion">
+            <p>Baby Lotion</p>
+        </div>
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1620733724354-9d5900eef0c2?auto=format&fit=crop&w=400&q=60" alt="Sunscreen">
+            <p>Kids Sunscreen</p>
+        </div>
+    </section>
+</main>
+<footer>
+    <p>&copy; 2023 Megumi. Ships within India.</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/cart.html
+++ b/cart.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cart - Megumi</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://checkout.razorpay.com/v1/checkout.js"></script>
+</head>
+<body>
+<header>
+    <h1>Your Cart</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="all-products.html">All Products</a></li>
+            <li><a href="clothes.html">Clothes</a></li>
+            <li><a href="toys.html">Toys</a></li>
+            <li><a href="care.html">Care</a></li>
+            <li><a href="cart.html">Cart</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section class="product-grid">
+        <div class="product">
+            <img src="https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=400&q=60" alt="Sample Item">
+            <p>Sample Item</p>
+            <p>₹500</p>
+        </div>
+    </section>
+    <div style="text-align:center; padding:2rem;">
+        <button id="pay-button" style="padding:1rem 2rem; background:#d62828; color:#fff; border:none;">Pay Now</button>
+    </div>
+</main>
+<footer>
+    <p>&copy; 2023 Megumi. Ships within India.</p>
+</footer>
+<script src="script.js"></script>
+<script>
+    document.getElementById('pay-button').onclick = function(e){
+        var options = {
+            "key": "rzp_test_1DP5mmOlF5G5ag", // Test key
+            "amount": "50000", // 500 INR
+            "currency": "INR",
+            "name": "Megumi",
+            "description": "Test Transaction",
+            "handler": function (response){
+                alert('Payment successful. Payment ID: ' + response.razorpay_payment_id);
+            },
+            "prefill": {
+                "name": "",
+                "email": "",
+                "contact": ""
+            },
+            "theme": {
+                "color": "#d62828"
+            }
+        };
+        var rzp1 = new Razorpay(options);
+        rzp1.open();
+        e.preventDefault();
+    }
+</script>
+</body>
+</html>

--- a/clothes.html
+++ b/clothes.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kids Clothes - Megumi</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+    <h1>Kids Clothes</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="all-products.html">All Products</a></li>
+            <li><a href="clothes.html">Clothes</a></li>
+            <li><a href="toys.html">Toys</a></li>
+            <li><a href="care.html">Care</a></li>
+            <li><a href="cart.html">Cart</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section>
+        <h2>Boys</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1520975918318-3a4b289f7e8d?auto=format&fit=crop&w=400&q=60" alt="Boys Shirt">
+                <p>Casual Shirt</p>
+            </div>
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1504151932400-72d4384f04b3?auto=format&fit=crop&w=400&q=60" alt="Boys Jacket">
+                <p>Light Jacket</p>
+            </div>
+        </div>
+    </section>
+    <section>
+        <h2>Girls</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=400&q=60" alt="Girls Dress">
+                <p>Summer Dress</p>
+            </div>
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1522337360788-8b142ad442f7?auto=format&fit=crop&w=400&q=60" alt="Girls Shirt">
+                <p>Cotton Top</p>
+            </div>
+        </div>
+    </section>
+</main>
+<footer>
+    <p>&copy; 2023 Megumi. Ships within India.</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Megumi Kids Store</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Megumi</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="all-products.html">All Products</a></li>
+                <li><a href="clothes.html">Clothes</a></li>
+                <li><a href="toys.html">Toys</a></li>
+                <li><a href="care.html">Care</a></li>
+                <li><a href="cart.html">Cart</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="hero">
+            <h2>Japanese inspired essentials for kids 0-16</h2>
+            <p>Simple. Playful. Gentle.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Megumi. Ships within India.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1 @@
+console.log('Welcome to Megumi');

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #fff;
+    color: #333;
+}
+
+header {
+    background-color: #d62828; /* Uniqlo red */
+    color: white;
+    padding: 1rem;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 1rem;
+}
+
+nav a {
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.hero {
+    background-color: #f5f5f5; /* Muji neutral */
+    padding: 4rem 2rem;
+    text-align: center;
+}
+
+section h2 {
+    color: #d62828;
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    padding: 2rem;
+}
+
+.product {
+    background: #fff;
+    border: 1px solid #eee;
+    padding: 1rem;
+    text-align: center;
+}
+
+footer {
+    background-color: #eee;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}

--- a/toys.html
+++ b/toys.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kids Toys - Megumi</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+    <h1>Kids Toys</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="all-products.html">All Products</a></li>
+            <li><a href="clothes.html">Clothes</a></li>
+            <li><a href="toys.html">Toys</a></li>
+            <li><a href="care.html">Care</a></li>
+            <li><a href="cart.html">Cart</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section>
+        <h2>Unisex</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1609947793902-03cf9d36fb40?auto=format&fit=crop&w=400&q=60" alt="Blocks">
+                <p>Wooden Blocks</p>
+            </div>
+        </div>
+    </section>
+    <section>
+        <h2>Boys</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1506097425191-7ad538b29cef?auto=format&fit=crop&w=400&q=60" alt="Toy Car">
+                <p>Race Car</p>
+            </div>
+        </div>
+    </section>
+    <section>
+        <h2>Girls</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1609931021287-6403d2721c53?auto=format&fit=crop&w=400&q=60" alt="Doll">
+                <p>Soft Doll</p>
+            </div>
+        </div>
+    </section>
+    <section>
+        <h2>Toddler</h2>
+        <div class="product-grid">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1603312573470-675bc0a9a7de?auto=format&fit=crop&w=400&q=60" alt="Toddler Toy">
+                <p>Stacking Rings</p>
+            </div>
+        </div>
+    </section>
+</main>
+<footer>
+    <p>&copy; 2023 Megumi. Ships within India.</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build static Megumi kids store with Japanese-inspired styling
- Add pages for clothing, toys, care products and Razorpay checkout

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea63e1f90832f89071cde75b18739