### PR TITLE
Add basic login page and Express OAuth server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
         <title>Emergent | Fullstack App</title>
-    <script defer src="static/js/bundle.js"></script></head>
+        <script defer src="static/js/bundle.js"></script>
+        <script defer src="static/js/login-link.js"></script>
+    </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Login</title>
+  </head>
+  <body>
+    <h1>Login</h1>
+    <p><a href="/auth/google">Login with Google</a></p>
+    <p><a href="/auth/facebook">Login with Facebook</a></p>
+  </body>
+</html>

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema({
+  displayName: String,
+  email: String,
+  googleId: String,
+  facebookId: String,
+  wishlist: [String],
+  orderHistory: [String],
+  activities: [String],
+}, { timestamps: true });
+
+module.exports = mongoose.model('User', UserSchema);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chatgpt-website-help",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --check server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^8.4.0",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "passport-facebook": "^3.0.0",
+    "express-session": "^1.17.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,98 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const session = require('express-session');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const FacebookStrategy = require('passport-facebook').Strategy;
+const User = require('./models/User');
+
+const app = express();
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/chatgptwebsitehelp');
+
+passport.serializeUser((user, done) => done(null, user.id));
+passport.deserializeUser(async (id, done) => {
+  try {
+    const user = await User.findById(id);
+    done(null, user);
+  } catch (err) {
+    done(err);
+  }
+});
+
+passport.use(new GoogleStrategy(
+  {
+    clientID: process.env.GOOGLE_CLIENT_ID || 'GOOGLE_CLIENT_ID',
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'GOOGLE_CLIENT_SECRET',
+    callbackURL: '/auth/google/callback',
+  },
+  async (accessToken, refreshToken, profile, done) => {
+    try {
+      let user = await User.findOne({ googleId: profile.id });
+      if (!user) {
+        user = await User.create({
+          googleId: profile.id,
+          displayName: profile.displayName,
+          email: profile.emails && profile.emails[0] ? profile.emails[0].value : undefined,
+        });
+      }
+      return done(null, user);
+    } catch (err) {
+      return done(err, null);
+    }
+  }
+));
+
+passport.use(new FacebookStrategy(
+  {
+    clientID: process.env.FACEBOOK_CLIENT_ID || 'FACEBOOK_CLIENT_ID',
+    clientSecret: process.env.FACEBOOK_CLIENT_SECRET || 'FACEBOOK_CLIENT_SECRET',
+    callbackURL: '/auth/facebook/callback',
+    profileFields: ['id', 'displayName', 'emails'],
+  },
+  async (accessToken, refreshToken, profile, done) => {
+    try {
+      let user = await User.findOne({ facebookId: profile.id });
+      if (!user) {
+        user = await User.create({
+          facebookId: profile.id,
+          displayName: profile.displayName,
+          email: profile.emails && profile.emails[0] ? profile.emails[0].value : undefined,
+        });
+      }
+      return done(null, user);
+    } catch (err) {
+      return done(err, null);
+    }
+  }
+));
+
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'secret',
+  resave: false,
+  saveUninitialized: false,
+}));
+app.use(passport.initialize());
+app.use(passport.session());
+
+app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+app.get('/auth/google/callback',
+  passport.authenticate('google', { failureRedirect: '/login.html' }),
+  (req, res) => { res.redirect('/'); }
+);
+
+app.get('/auth/facebook', passport.authenticate('facebook', { scope: ['email'] }));
+app.get('/auth/facebook/callback',
+  passport.authenticate('facebook', { failureRedirect: '/login.html' }),
+  (req, res) => { res.redirect('/'); }
+);
+
+app.get('/api/user', (req, res) => {
+  if (req.user) {
+    res.json(req.user);
+  } else {
+    res.status(401).json({ error: 'Not authenticated' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/static/js/login-link.js
+++ b/static/js/login-link.js
@@ -1,0 +1,22 @@
+// Attach login navigation to any user icon buttons rendered by the app
+// Observes the DOM so the handler persists across page changes.
+document.addEventListener('DOMContentLoaded', () => {
+  const attach = () => {
+    document.querySelectorAll('svg.lucide-user').forEach(icon => {
+      const btn = icon.closest('button');
+      if (btn && !btn.dataset.loginAttached) {
+        btn.dataset.loginAttached = 'true';
+        btn.addEventListener('click', () => {
+          window.location.href = 'login.html';
+        });
+      }
+    });
+  };
+
+  // initial attempt
+  attach();
+
+  // observe DOM for dynamically added icons
+  const observer = new MutationObserver(attach);
+  observer.observe(document.body, { childList: true, subtree: true });
+});


### PR DESCRIPTION
## Summary
- Add login link to site and new login page with Google and Facebook buttons
- Introduce Express server using Passport for Google and Facebook OAuth and MongoDB persistence
- Define Mongoose user model and package configuration for running the server
- Replace landing-page login link with script-driven user icon after theme selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda03cd50832f81c419180c6ff2ab